### PR TITLE
Fix chart export on touch devices and print

### DIFF
--- a/web/static/css/style.css
+++ b/web/static/css/style.css
@@ -2084,8 +2084,16 @@ tbody tr:hover {
 }
 
 .homepage-chart-card:hover .chart-export-controls,
-.card:hover .chart-export-controls {
+.card:hover .chart-export-controls,
+.homepage-chart-card:focus-within .chart-export-controls,
+.card:focus-within .chart-export-controls {
     opacity: 1;
+}
+
+@media (hover: none) {
+    .chart-export-controls {
+        opacity: 1;
+    }
 }
 
 .chart-export-btn {
@@ -2136,6 +2144,7 @@ tbody tr:hover {
     .btn,
     button,
     .theme-toggle,
+    .chart-export-controls,
     .quick-select-buttons,
     .export-buttons,
     .homepage-chart-footer,


### PR DESCRIPTION
## Summary
- Show chart export (PNG/CSV) buttons on touch devices using `@media (hover: none)` 
- Add `focus-within` trigger for keyboard accessibility
- Explicitly hide `.chart-export-controls` in print stylesheet

Follow-up to v2 verification testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)